### PR TITLE
Fix undefined behavior in pseudonyms

### DIFF
--- a/prescription.yaml
+++ b/prescription.yaml
@@ -44,7 +44,6 @@ spec:
             yield_matched_version: true
             package_version:
               name: intel-tensorflow
-              locked_version: "==1.0.0"
               index_url: "https://pypi.org/simple"
       - name: IntelTensorFlowCPUPseudonym
         type: pseudonym
@@ -71,7 +70,6 @@ spec:
             yield_matched_version: true
             package_version:
               name: intel-tensorflow
-              locked_version: "==1.0.0"
               index_url: "https://pypi.org/simple"
     sieves:
       - name: Enum34BackportSieve


### PR DESCRIPTION
## Related issues or additional information of the supplied change

```
2021-03-19 20:13:02,129 184811 ERROR    thoth.adviser.prescription.v1.prescription:120: Error in unit IntelTensorFlowPseudonym (pseudonym): Using 'yield_matched_version' together with 'locked_version' leads to undefined behavior
2021-03-19 20:13:02,129 184811 ERROR    thoth.adviser.prescription.v1.prescription:120: Error in unit IntelTensorFlowCPUPseudonym (pseudonym): Using 'yield_matched_version' together with 'locked_version' leads to undefined behavior
```