### PR TITLE
prescription regarding the pycurl installation with ssl library

### DIFF
--- a/prescriptions/py_/pycurl/ubi8_nss.yaml
+++ b/prescriptions/py_/pycurl/ubi8_nss.yaml
@@ -1,0 +1,22 @@
+units:
+  wraps:
+    - name: PycurlUbi8SSL
+      type: wrap
+      should_include:
+        adviser_pipeline: true
+        runtime_environments:
+          operating_systems:
+            - name: rhel
+              version: "8"
+      match:
+        state:
+          resolved_dependencies:
+            - name: pycurl
+              index_url: 'https://pypi.org/simple'
+      run:
+        stack_info:
+          - type: INFO
+            message: >
+              "Package 'pycurl' require 'libcurl' to be built against as the runtime,"
+              "pycurl require pip args `--install-option="--with-nss"` to determine SSL library"
+            link: http://pycurl.io/docs/latest/install.html#ssl


### PR DESCRIPTION
prescription regarding the pycurl installation with ssl library
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

#### What type of PR is this?

/kind bug

## Related issues or additional information of the supplied change

https://github.com/pypa/pipenv/issues/1284
https://gist.github.com/ifduyue/ccc644f146657ccb9e60f0af676f1923
http://pycurl.io/docs/latest/install.html#ssl

## Description

This states a fix for the issue caused by the mismatch of SSL library between build time and runtime w.r.t pycurl package.