### PR TITLE
Penalize resolution of Torch rather than filtering releases

### DIFF
--- a/prescriptions/to_/torch/cpu_index.yaml
+++ b/prescriptions/to_/torch/cpu_index.yaml
@@ -1,17 +1,18 @@
 units:
-  sieves:
+  steps:
   - name: TorchCPUIndex
-    type: sieve
+    type: step
     should_include:
       adviser_pipeline: true
       runtime_environments:
         cuda_version: null
     match:
-    - package_version:
+      package_version:
         name: torch
         index_url:
           not: https://download.pytorch.org/whl/cpu
     run:
+      score: -0.1
       log:
         message: Using torch releases from Torch CPU Python Package index
         type: INFO

--- a/prescriptions/to_/torch/gpu_index.yaml
+++ b/prescriptions/to_/torch/gpu_index.yaml
@@ -1,17 +1,18 @@
 units:
-  sieves:
+  steps:
   - name: TorchGPUIndex
-    type: sieve
+    type: step
     should_include:
       adviser_pipeline: true
       runtime_environments:
         cuda_version: ==11.1
     match:
-    - package_version:
+      package_version:
         name: torch
         index_url:
           not: https://download.pytorch.org/whl/cu111
     run:
+      score: -0.1
       log:
         message: Using Torch releases from Torch GPU Python Package index for CUDA 11.1
         type: INFO


### PR DESCRIPTION
This way, we will be able to resolve Torch packages from Torch index with higher priority if possible. If not, the resolution process will fallback to releases from other indexes instead of completelly filtering them.