### PR TITLE
Add runtime environment to predictable stack prescription for pytorch and opencv

### DIFF
--- a/prescriptions/_predictable_stacks/ps_cv_torch.yaml
+++ b/prescriptions/_predictable_stacks/ps_cv_torch.yaml
@@ -6,6 +6,10 @@ units:
       adviser_pipeline: true
       runtime_environments:
         base_images: [null]  # Only if no base image is used.
+        operating_systems:
+        - name: rhel
+          version: '8'
+        python_version: '==3.8'
     match:
     - package_name: opencv-python
     - package_name: torch


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

#### What type of PR is this?

/kind feature

## Related issues or additional information of the supplied change

Prescription for predictable stack should include also runtime environment for which the image should be recommended with certain packages. We don't want to recommend a certain image if the runtime environment was different from the one requested.