### PR TITLE
Introduce prescription for sparsify and tensorflow from Neural Magic

### DIFF
--- a/prescriptions/sp_/sparsify/tf.yaml
+++ b/prescriptions/sp_/sparsify/tf.yaml
@@ -42,4 +42,4 @@ units:
         message: >-
           maximum tensorflow version supported by sparsify is 1.16.0
         link: https://github.com/neuralmagic/sparsify/issues/83
-        package_name: tensorflow
+        package_name: sparsify


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

#### What type of PR is this?

/kind feature


## Related issues or additional information of the supplied change
Related-To: https://github.com/neuralmagic/sparsify/issues/83

## Description
Sparsify library to this version 0.7.0 supports maximum tensorflow version 1.16.0

Thoth resolution engine will accept tensorflow versions if they are `<1.16.0`. In this way the user will directly recieve the tensorflow version to use correctly the sparsify library.
 
cc @markurtz
