### PR TITLE
Use CPU database for AVX2 enabled CPUs matching AICoE builds of TensorFlow

### DIFF
--- a/prescriptions/_aicoe/tf_avx2.yaml
+++ b/prescriptions/_aicoe/tf_avx2.yaml
@@ -10,18 +10,7 @@ units:
       - stable
       runtime_environments:
         hardware:
-        - cpu_families: [6]
-          # See:
-          #   https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX2
-          #   https://en.wikichip.org/wiki/intel/cpuid
-          # 0x5 Cascade Lake
-          # 0x6 Broadwell, Cannon Lake
-          # 0xA Ice Lake
-          # 0xC Ice Lake, Tiger Lake
-          # 0xD Ice Lake
-          # 0xE Skylake, Kaby Lake, Coffee Lake, Ice Lake, Comet Lake, Whiskey Lake
-          # 0xF Haswell
-          cpu_models: [5, 6, 10, 12, 13, 14, 15, 16]
+        - cpu_flags: [avx2]
     match:
       package_version:
         name: tensorflow


### PR DESCRIPTION
## Related issues or additional information of the supplied change

Related: https://github.com/thoth-station/adviser/pull/2116

## Description

Use CPU database to match CPU tags available on the client machine.
