### PR TITLE
Use an https URL in pre-commit references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
-- repo: git://github.com/Lucas-C/pre-commit-hooks
+- repo: https://github.com/Lucas-C/pre-commit-hooks
   rev: v1.1.10
   hooks:
   - id: remove-tabs


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

## Related issues or additional information of the supplied change

#18541 
thoth-station/thoth-application#2111

## Description

From thoth-station/thoth-application#2111:

GitHub has recently upgraded its clone methods for more security.
It would no longer support the SHA-1 method.

November 2, 2021, was the deadline to switch, hence we are facing the issue.

Details: https://github.blog/2021-09-01-improving-git-protocol-security-github/#dropping-insecure-signature-algorithms
