### PR TITLE
Configure prow resources

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -11,3 +11,10 @@ presubmits:
       - pre-commit
       - run
       - --all-files
+      resources:
+        requests:
+          memory: 1Gi
+          cpu: 1
+        limits:
+          memory: 1Gi
+          cpu: 1


### PR DESCRIPTION
## Related issues or additional information of the supplied change

It looks like prow job for pre-commit in this repo takes way too long (35-50mins). I'm not sure what are the default resources assigned to a prow job hence raising this here and checking if this adjustment will make things more fluent. YAML lint is really consuming a lot of resources given the YAML files count.
