### PR TITLE
Add prescriptions that show container image size of used containers

### DIFF
--- a/prescriptions/_containers/ps_cv_ocr/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_cv_ocr/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsCvOcrV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-cv-ocr:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-cv-ocr:v0.1.1' has a size of 1.37GiB
+        link: https://quay.io/thoth-station/ps-cv-ocr:v0.1.1
+  - name: PsCvOcrV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-cv-ocr:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-cv-ocr:v0.1.2' has a size of 1.37GiB
+        link: https://quay.io/thoth-station/ps-cv-ocr:v0.1.2

--- a/prescriptions/_containers/ps_cv_pytorch/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_cv_pytorch/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsCvPytorchV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-cv-pytorch:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-cv-pytorch:v0.1.2' has a size of 1.96GiB
+        link: https://quay.io/thoth-station/ps-cv-pytorch:v0.1.2
+  - name: PsCvPytorchV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-cv-pytorch:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-cv-pytorch:v0.1.1' has a size of 1.96GiB
+        link: https://quay.io/thoth-station/ps-cv-pytorch:v0.1.1

--- a/prescriptions/_containers/ps_cv_tensorflow/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_cv_tensorflow/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsCvTensorflowV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-cv-tensorflow:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-cv-tensorflow:v0.1.2' has a size of 1.60GiB
+        link: https://quay.io/thoth-station/ps-cv-tensorflow:v0.1.2
+  - name: PsCvTensorflowV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-cv-tensorflow:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-cv-tensorflow:v0.1.1' has a size of 1.60GiB
+        link: https://quay.io/thoth-station/ps-cv-tensorflow:v0.1.1

--- a/prescriptions/_containers/ps_ip_ifd/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_ip_ifd/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsIpIfdV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-ip-ifd:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-ip-ifd:v0.1.1' has a size of 1.19GiB
+        link: https://quay.io/thoth-station/ps-ip-ifd:v0.1.1
+  - name: PsIpIfdV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-ip-ifd:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-ip-ifd:v0.1.2' has a size of 1.19GiB
+        link: https://quay.io/thoth-station/ps-ip-ifd:v0.1.2

--- a/prescriptions/_containers/ps_nlp/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_nlp/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsNlpV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-nlp:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-nlp:v0.1.0' has a size of 1.16GiB
+        link: https://quay.io/thoth-station/ps-nlp:v0.1.0
+  - name: PsNlpV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-nlp:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-nlp:v0.1.1' has a size of 1.08GiB
+        link: https://quay.io/thoth-station/ps-nlp:v0.1.1

--- a/prescriptions/_containers/ps_nlp_pytorch/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_nlp_pytorch/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsNlpPytorchV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-nlp-pytorch:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-nlp-pytorch:v0.1.0' has a size of 2.03GiB
+        link: https://quay.io/thoth-station/ps-nlp-pytorch:v0.1.0
+  - name: PsNlpPytorchV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-nlp-pytorch:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-nlp-pytorch:v0.1.1' has a size of 1.95GiB
+        link: https://quay.io/thoth-station/ps-nlp-pytorch:v0.1.1

--- a/prescriptions/_containers/ps_nlp_tensorflow/quay_image_size.yaml
+++ b/prescriptions/_containers/ps_nlp_tensorflow/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: PsNlpTensorflowV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-nlp-tensorflow:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-nlp-tensorflow:v0.1.0' has a size of 1.66GiB
+        link: https://quay.io/thoth-station/ps-nlp-tensorflow:v0.1.0
+  - name: PsNlpTensorflowV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/ps-nlp-tensorflow:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/ps-nlp-tensorflow:v0.1.1' has a size of 1.60GiB
+        link: https://quay.io/thoth-station/ps-nlp-tensorflow:v0.1.1

--- a/prescriptions/_containers/s2i_custom_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_custom_notebook/quay_image_size.yaml
@@ -1,0 +1,184 @@
+units:
+  boots:
+  - name: S2iCustomNotebookV040QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.4.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.4.0' has a size of 647.11MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.4.0
+  - name: S2iCustomNotebookV042QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.4.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.4.2' has a size of 634.68MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.4.2
+  - name: S2iCustomNotebookV033QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.3.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.3.3' has a size of 640.47MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.3.3
+  - name: S2iCustomNotebookV021QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.2.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.2.1' has a size of 513.28MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.2.1
+  - name: S2iCustomNotebookV041QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.4.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.4.1' has a size of 647.11MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.4.1
+  - name: S2iCustomNotebookV043QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.4.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.4.3' has a size of 628.25MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.4.3
+  - name: S2iCustomNotebookV020QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.2.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.2.0' has a size of 513.28MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.2.0
+  - name: S2iCustomNotebookV031QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.3.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.3.1' has a size of 663.46MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.3.1
+  - name: S2iCustomNotebookV032QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.3.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.3.2' has a size of 640.47MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.3.2
+  - name: S2iCustomNotebookV002QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.0.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.0.2' has a size of 513.28MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.0.2
+  - name: S2iCustomNotebookV022QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.2.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.2.2' has a size of 536.50MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.2.2
+  - name: S2iCustomNotebookV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.1.0' has a size of 513.28MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.1.0
+  - name: S2iCustomNotebookV023QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.2.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.2.3' has a size of 663.46MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.2.3
+  - name: S2iCustomNotebookV030QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-notebook:v0.3.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-notebook:v0.3.0' has a size of 663.46MiB
+        link: https://quay.io/thoth-station/s2i-custom-notebook:v0.3.0

--- a/prescriptions/_containers/s2i_custom_py38_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_custom_py38_notebook/quay_image_size.yaml
@@ -1,0 +1,106 @@
+units:
+  boots:
+  - name: S2iCustomPy38NotebookV031QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.1' has a size of 657.50MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.1
+  - name: S2iCustomPy38NotebookV032QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.2' has a size of 696.24MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.2
+  - name: S2iCustomPy38NotebookV033QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.3' has a size of 688.69MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.3
+  - name: S2iCustomPy38NotebookV043QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.3' has a size of 650.95MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.3
+  - name: S2iCustomPy38NotebookV041QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.1' has a size of 687.83MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.1
+  - name: S2iCustomPy38NotebookV040QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.0' has a size of 687.83MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.0
+  - name: S2iCustomPy38NotebookV042QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.2' has a size of 659.78MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.4.2
+  - name: S2iCustomPy38NotebookV030QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.0' has a size of 651.11MiB
+        link: https://quay.io/thoth-station/s2i-custom-py38-notebook:v0.3.0

--- a/prescriptions/_containers/s2i_elyra_custom_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_elyra_custom_notebook/quay_image_size.yaml
@@ -1,0 +1,106 @@
+units:
+  boots:
+  - name: S2iElyraCustomNotebookV043QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.3' has a size of 822.01MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.3
+  - name: S2iElyraCustomNotebookV040QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.0' has a size of 853.07MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.0
+  - name: S2iElyraCustomNotebookV041QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.1' has a size of 853.07MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.1
+  - name: S2iElyraCustomNotebookV032QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.2' has a size of 904.09MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.2
+  - name: S2iElyraCustomNotebookV030QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.0' has a size of 856.27MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.0
+  - name: S2iElyraCustomNotebookV042QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.2' has a size of 832.45MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.4.2
+  - name: S2iElyraCustomNotebookV033QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.3' has a size of 897.21MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.3
+  - name: S2iElyraCustomNotebookV031QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.1' has a size of 864.22MiB
+        link: https://quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.1

--- a/prescriptions/_containers/s2i_generic_data_science_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_generic_data_science_notebook/quay_image_size.yaml
@@ -1,0 +1,67 @@
+units:
+  boots:
+  - name: S2iGenericDataScienceNotebookV002QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.2' has a size of 882.93MiB
+        link: https://quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.2
+  - name: S2iGenericDataScienceNotebookV003QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.3' has a size of 882.85MiB
+        link: https://quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.3
+  - name: S2iGenericDataScienceNotebookV001QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.1' has a size of 890.61MiB
+        link: https://quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.1
+  - name: S2iGenericDataScienceNotebookV004QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.4' has a size of 1.01GiB
+        link: https://quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.4
+  - name: S2iGenericDataScienceNotebookV005QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.5
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.5' has a size of 1012.08MiB
+        link: https://quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.5

--- a/prescriptions/_containers/s2i_jupyterbook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_jupyterbook/quay_image_size.yaml
@@ -1,0 +1,15 @@
+units:
+  boots:
+  - name: S2iJupyterbookV0130QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-jupyterbook:v0.13.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-jupyterbook:v0.13.0' has a size of 410.83MiB
+        link: https://quay.io/thoth-station/s2i-jupyterbook:v0.13.0

--- a/prescriptions/_containers/s2i_lab_elyra/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_lab_elyra/quay_image_size.yaml
@@ -1,0 +1,197 @@
+units:
+  boots:
+  - name: S2iLabElyraV009QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.9
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.9' has a size of 856.26MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.9
+  - name: S2iLabElyraV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.1.0' has a size of 832.44MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.1.0
+  - name: S2iLabElyraV0012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.12
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.12' has a size of 897.21MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.12
+  - name: S2iLabElyraV0011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.11
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.11' has a size of 904.09MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.11
+  - name: S2iLabElyraV002QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.2' has a size of 813.65MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.2
+  - name: S2iLabElyraV001QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.1' has a size of 698.51MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.1
+  - name: S2iLabElyraV003QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.3' has a size of 834.96MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.3
+  - name: S2iLabElyraV005QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.5
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.5' has a size of 883.18MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.5
+  - name: S2iLabElyraV004QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.4' has a size of 863.00MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.4
+  - name: S2iLabElyraV0010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.10
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.10' has a size of 864.21MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.10
+  - name: S2iLabElyraV0013QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.13
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.13' has a size of 853.07MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.13
+  - name: S2iLabElyraV008QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.8
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.8' has a size of 1.02GiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.8
+  - name: S2iLabElyraV006QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.6' has a size of 978.28MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.6
+  - name: S2iLabElyraV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.1.1' has a size of 822.00MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.1.1
+  - name: S2iLabElyraV007QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-lab-elyra:v0.0.7
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-lab-elyra:v0.0.7' has a size of 962.41MiB
+        link: https://quay.io/thoth-station/s2i-lab-elyra:v0.0.7

--- a/prescriptions/_containers/s2i_minimal_f34_py39_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_minimal_f34_py39_notebook/quay_image_size.yaml
@@ -1,0 +1,41 @@
+units:
+  boots:
+  - name: S2iMinimalF34Py39NotebookV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.1.2' has a size of 992.83MiB
+        link: https://quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.1.2
+  - name: S2iMinimalF34Py39NotebookV021QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.2.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.2.1' has a size of 704.52MiB
+        link: https://quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.2.1
+  - name: S2iMinimalF34Py39NotebookV022QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.2.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.2.2' has a size of 664.10MiB
+        link: https://quay.io/thoth-station/s2i-minimal-f34-py39-notebook:v0.2.2

--- a/prescriptions/_containers/s2i_minimal_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_minimal_notebook/quay_image_size.yaml
@@ -1,0 +1,262 @@
+units:
+  boots:
+  - name: S2iMinimalNotebookV008QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.8
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.8' has a size of 479.91MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.8
+  - name: S2iMinimalNotebookV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.1.0' has a size of 640.47MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.1.0
+  - name: S2iMinimalNotebookV021QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.2.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.2.1' has a size of 634.67MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.2.1
+  - name: S2iMinimalNotebookV006QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.6' has a size of 478.85MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.6
+  - name: S2iMinimalNotebookV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.1.1' has a size of 640.47MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.1.1
+  - name: S2iMinimalNotebookV0013QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.13
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.13' has a size of 613.60MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.13
+  - name: S2iMinimalNotebookV0015QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.15
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.15' has a size of 615.65MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.15
+  - name: S2iMinimalNotebookV0012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.12
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.12' has a size of 609.50MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.12
+  - name: S2iMinimalNotebookV003QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.3' has a size of 513.28MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.3
+  - name: S2iMinimalNotebookV0010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.10
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.10' has a size of 538.53MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.10
+  - name: S2iMinimalNotebookV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.1.2' has a size of 647.11MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.1.2
+  - name: S2iMinimalNotebookV0016QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.16
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.16' has a size of 615.84MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.16
+  - name: S2iMinimalNotebookV005QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.5
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.5' has a size of 454.57MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.5
+  - name: S2iMinimalNotebookV0014QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.14
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.14' has a size of 623.33MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.14
+  - name: S2iMinimalNotebookV022QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.2.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.2.2' has a size of 628.24MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.2.2
+  - name: S2iMinimalNotebookV007QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.7
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.7' has a size of 663.45MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.7
+  - name: S2iMinimalNotebookV009QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.9
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.9' has a size of 480.06MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.9
+  - name: S2iMinimalNotebookV0017QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.17
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.17' has a size of 615.84MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.17
+  - name: S2iMinimalNotebookV004QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.4' has a size of 536.50MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
+  - name: S2iMinimalNotebookV0011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-notebook:v0.0.11
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-notebook:v0.0.11' has a size of 538.81MiB
+        link: https://quay.io/thoth-station/s2i-minimal-notebook:v0.0.11

--- a/prescriptions/_containers/s2i_minimal_py38_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_minimal_py38_notebook/quay_image_size.yaml
@@ -1,0 +1,171 @@
+units:
+  boots:
+  - name: S2iMinimalPy38NotebookV010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.0' has a size of 696.24MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.0
+  - name: S2iMinimalPy38NotebookV011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.1' has a size of 688.68MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.1
+  - name: S2iMinimalPy38NotebookV0017QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.17
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.17' has a size of 657.49MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.17
+  - name: S2iMinimalPy38NotebookV009QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.9
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.9' has a size of 546.74MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.9
+  - name: S2iMinimalPy38NotebookV022QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.2.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.2.2' has a size of 650.95MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.2.2
+  - name: S2iMinimalPy38NotebookV0013QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.13
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.13' has a size of 638.23MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.13
+  - name: S2iMinimalPy38NotebookV0016QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.16
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.16' has a size of 657.49MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.16
+  - name: S2iMinimalPy38NotebookV0010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.10
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.10' has a size of 553.57MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.10
+  - name: S2iMinimalPy38NotebookV0011QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.11
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.11' has a size of 553.91MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.11
+  - name: S2iMinimalPy38NotebookV0015QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.15
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.15' has a size of 651.11MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.15
+  - name: S2iMinimalPy38NotebookV0014QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.14
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.14' has a size of 638.21MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.14
+  - name: S2iMinimalPy38NotebookV012QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.2' has a size of 687.83MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.1.2
+  - name: S2iMinimalPy38NotebookV021QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-minimal-py38-notebook:v0.2.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-minimal-py38-notebook:v0.2.1' has a size of 659.78MiB
+        link: https://quay.io/thoth-station/s2i-minimal-py38-notebook:v0.2.1

--- a/prescriptions/_containers/s2i_pytorch_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_pytorch_notebook/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: S2iPytorchNotebookV001QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-pytorch-notebook:v0.0.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-pytorch-notebook:v0.0.1' has a size of 1.55GiB
+        link: https://quay.io/thoth-station/s2i-pytorch-notebook:v0.0.1
+  - name: S2iPytorchNotebookV002QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-pytorch-notebook:v0.0.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-pytorch-notebook:v0.0.2' has a size of 1.56GiB
+        link: https://quay.io/thoth-station/s2i-pytorch-notebook:v0.0.2

--- a/prescriptions/_containers/s2i_scipy_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_scipy_notebook/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: S2iScipyNotebookV001QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-scipy-notebook:v0.0.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-scipy-notebook:v0.0.1' has a size of 822.42MiB
+        link: https://quay.io/thoth-station/s2i-scipy-notebook:v0.0.1
+  - name: S2iScipyNotebookV002QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-scipy-notebook:v0.0.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-scipy-notebook:v0.0.2' has a size of 955.97MiB
+        link: https://quay.io/thoth-station/s2i-scipy-notebook:v0.0.2

--- a/prescriptions/_containers/s2i_tensorflow_notebook/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_tensorflow_notebook/quay_image_size.yaml
@@ -1,0 +1,28 @@
+units:
+  boots:
+  - name: S2iTensorflowNotebookV001QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.1' has a size of 1.15GiB
+        link: https://quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.1
+  - name: S2iTensorflowNotebookV002QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.2' has a size of 1.29GiB
+        link: https://quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.2

--- a/prescriptions/_containers/s2i_thoth_dev/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_dev/quay_image_size.yaml
@@ -1,0 +1,15 @@
+units:
+  boots:
+  - name: S2iThothDevV0130QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-dev:v0.13.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-dev:v0.13.0' has a size of 351.44MiB
+        link: https://quay.io/thoth-station/s2i-thoth-dev:v0.13.0

--- a/prescriptions/_containers/s2i_thoth_f31_py37/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_f31_py37/quay_image_size.yaml
@@ -1,0 +1,678 @@
+units:
+  boots:
+  - name: S2iThothF31Py37V01114QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.14
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.14' has a size of 368.31MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.14
+  - name: S2iThothF31Py37V01115QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.15
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.15' has a size of 368.31MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.15
+  - name: S2iThothF31Py37V0112QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.2' has a size of 339.64MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.2
+  - name: S2iThothF31Py37V0114QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.4' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.4
+  - name: S2iThothF31Py37V0140QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.0' has a size of 299.89MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.0
+  - name: S2iThothF31Py37V01112QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.12
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.12' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.12
+  - name: S2iThothF31Py37V0242QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.2' has a size of 308.88MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.2
+  - name: S2iThothF31Py37V0142QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.2' has a size of 299.88MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.2
+  - name: S2iThothF31Py37V0131QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.13.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.13.1' has a size of 299.92MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.13.1
+  - name: S2iThothF31Py37V090QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.9.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.9.0' has a size of 299.95MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.9.0
+  - name: S2iThothF31Py37V0120QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.0' has a size of 368.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.0
+  - name: S2iThothF31Py37V0116QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.6' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.6
+  - name: S2iThothF31Py37V0117QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.7
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.7' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.7
+  - name: S2iThothF31Py37V0118QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.8
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.8' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.8
+  - name: S2iThothF31Py37V0119QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.9
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.9' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.9
+  - name: S2iThothF31Py37V0141QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.1' has a size of 299.87MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.14.1
+  - name: S2iThothF31Py37V0290QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.29.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.29.0' has a size of 316.43MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.29.0
+  - name: S2iThothF31Py37V0100QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.10.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.10.0' has a size of 299.95MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.10.0
+  - name: S2iThothF31Py37V0190QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.19.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.19.0' has a size of 307.55MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.19.0
+  - name: S2iThothF31Py37V01111QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.11
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.11' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.11
+  - name: S2iThothF31Py37V0250QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.25.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.25.0' has a size of 308.88MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.25.0
+  - name: S2iThothF31Py37V0151QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.15.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.15.1' has a size of 299.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.15.1
+  - name: S2iThothF31Py37V070QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.7.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.7.0' has a size of 310.40MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.7.0
+  - name: S2iThothF31Py37V0170QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.17.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.17.0' has a size of 299.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.17.0
+  - name: S2iThothF31Py37V0280QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.28.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.28.0' has a size of 316.44MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.28.0
+  - name: S2iThothF31Py37V0180QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.18.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.18.0' has a size of 302.40MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.18.0
+  - name: S2iThothF31Py37V01110QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.10
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.10' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.10
+  - name: S2iThothF31Py37V0220QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.22.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.22.0' has a size of 308.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.22.0
+  - name: S2iThothF31Py37V0115QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.5
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.5' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.5
+  - name: S2iThothF31Py37V01116QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.16
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.16' has a size of 368.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.16
+  - name: S2iThothF31Py37V080QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.8.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.8.0' has a size of 310.79MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.8.0
+  - name: S2iThothF31Py37V0231QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.1' has a size of 308.33MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.1
+  - name: S2iThothF31Py37V0211QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.1' has a size of 307.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.1
+  - name: S2iThothF31Py37V0230QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.0' has a size of 308.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.0
+  - name: S2iThothF31Py37V0240QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.0' has a size of 308.33MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.0
+  - name: S2iThothF31Py37V0124QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.4' has a size of 311.39MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.4
+  - name: S2iThothF31Py37V0260QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.26.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.26.0' has a size of 309.01MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.26.0
+  - name: S2iThothF31Py37V01113QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.13
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.13' has a size of 339.30MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.13
+  - name: S2iThothF31Py37V0212QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.2' has a size of 308.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.2
+  - name: S2iThothF31Py37V0121QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.1' has a size of 368.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.1
+  - name: S2iThothF31Py37V0210QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.0' has a size of 307.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.21.0
+  - name: S2iThothF31Py37V0123QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.3' has a size of 368.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.3
+  - name: S2iThothF31Py37V0200QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.20.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.20.0' has a size of 307.54MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.20.0
+  - name: S2iThothF31Py37V0161QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.16.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.16.1' has a size of 299.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.16.1
+  - name: S2iThothF31Py37V0122QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.2' has a size of 368.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.12.2
+  - name: S2iThothF31Py37V0111QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.1' has a size of 325.24MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.1
+  - name: S2iThothF31Py37V0232QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.2' has a size of 308.33MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.2
+  - name: S2iThothF31Py37V0160QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.16.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.16.0' has a size of 299.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.16.0
+  - name: S2iThothF31Py37V0241QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.1' has a size of 290.89MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.24.1
+  - name: S2iThothF31Py37V0201QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.20.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.20.1' has a size of 307.54MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.20.1
+  - name: S2iThothF31Py37V0270QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.27.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.27.0' has a size of 316.43MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.27.0
+  - name: S2iThothF31Py37V0113QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.3' has a size of 339.29MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f31-py37:v0.11.3

--- a/prescriptions/_containers/s2i_thoth_f32_py38/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_f32_py38/quay_image_size.yaml
@@ -1,0 +1,392 @@
+units:
+  boots:
+  - name: S2iThothF32Py38V0232QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.2' has a size of 333.61MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.2
+  - name: S2iThothF32Py38V0270QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.27.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.27.0' has a size of 341.73MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.27.0
+  - name: S2iThothF32Py38V0161QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.16.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.16.1' has a size of 384.79MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.16.1
+  - name: S2iThothF32Py38V0260QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.26.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.26.0' has a size of 334.31MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.26.0
+  - name: S2iThothF32Py38V0200QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.20.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.20.0' has a size of 322.66MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.20.0
+  - name: S2iThothF32Py38V0220QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.22.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.22.0' has a size of 323.22MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.22.0
+  - name: S2iThothF32Py38V0231QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.1' has a size of 333.61MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.1
+  - name: S2iThothF32Py38V0212QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.2' has a size of 323.22MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.2
+  - name: S2iThothF32Py38V0141QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.1' has a size of 384.55MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.1
+  - name: S2iThothF32Py38V0251QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.25.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.25.1' has a size of 334.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.25.1
+  - name: S2iThothF32Py38V0151QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.15.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.15.1' has a size of 384.78MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.15.1
+  - name: S2iThothF32Py38V0201QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.20.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.20.1' has a size of 322.66MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.20.1
+  - name: S2iThothF32Py38V0131QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.13.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.13.1' has a size of 384.57MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.13.1
+  - name: S2iThothF32Py38V0140QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.0' has a size of 384.57MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.0
+  - name: S2iThothF32Py38V0280QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.28.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.28.0' has a size of 341.73MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.28.0
+  - name: S2iThothF32Py38V0242QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.2' has a size of 334.16MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.2
+  - name: S2iThothF32Py38V0250QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.25.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.25.0' has a size of 334.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.25.0
+  - name: S2iThothF32Py38V0240QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.0' has a size of 333.61MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.0
+  - name: S2iThothF32Py38V0160QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.16.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.16.0' has a size of 384.79MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.16.0
+  - name: S2iThothF32Py38V0211QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.1' has a size of 322.96MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.1
+  - name: S2iThothF32Py38V0230QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.0' has a size of 333.60MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.0
+  - name: S2iThothF32Py38V0210QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.0' has a size of 322.96MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.21.0
+  - name: S2iThothF32Py38V0241QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.1' has a size of 316.03MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.24.1
+  - name: S2iThothF32Py38V0170QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.17.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.17.0' has a size of 384.79MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.17.0
+  - name: S2iThothF32Py38V0290QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.29.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.29.0' has a size of 341.73MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.29.0
+  - name: S2iThothF32Py38V0124QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.12.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.12.4' has a size of 359.89MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.12.4
+  - name: S2iThothF32Py38V0190QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.19.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.19.0' has a size of 322.66MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.19.0
+  - name: S2iThothF32Py38V0180QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.18.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.18.0' has a size of 387.34MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.18.0
+  - name: S2iThothF32Py38V0142QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.2' has a size of 384.57MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.14.2
+  - name: S2iThothF32Py38V0126QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f32-py38:v0.12.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f32-py38:v0.12.6' has a size of 359.66MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f32-py38:v0.12.6

--- a/prescriptions/_containers/s2i_thoth_f34_py39/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_f34_py39/quay_image_size.yaml
@@ -1,0 +1,93 @@
+units:
+  boots:
+  - name: S2iThothF34Py39V0323QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.3' has a size of 426.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.3
+  - name: S2iThothF34Py39V0290QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.29.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.29.0' has a size of 427.57MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.29.0
+  - name: S2iThothF34Py39V0320QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.0' has a size of 425.80MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.0
+  - name: S2iThothF34Py39V0310QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.0' has a size of 425.80MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.0
+  - name: S2iThothF34Py39V0321QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.1' has a size of 426.61MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.1
+  - name: S2iThothF34Py39V0322QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.2' has a size of 426.61MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.32.2
+  - name: S2iThothF34Py39V0311QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.1' has a size of 425.80MiB
+        link: https://quay.io/thoth-station/s2i-thoth-f34-py39:v0.31.1

--- a/prescriptions/_containers/s2i_thoth_ubi8_py36/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_ubi8_py36/quay_image_size.yaml
@@ -1,0 +1,860 @@
+units:
+  boots:
+  - name: S2iThothUbi8Py36V01116QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.16
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.16' has a size of 272.52MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.16
+  - name: S2iThothUbi8Py36V0100QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.10.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.10.0' has a size of 257.18MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.10.0
+  - name: S2iThothUbi8Py36V01112QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.12
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.12' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.12
+  - name: S2iThothUbi8Py36V0111QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.1' has a size of 257.19MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.1
+  - name: S2iThothUbi8Py36V0240QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.0' has a size of 329.35MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.0
+  - name: S2iThothUbi8Py36V0232QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.2' has a size of 329.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.2
+  - name: S2iThothUbi8Py36V0117QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.7
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.7' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.7
+  - name: S2iThothUbi8Py36V0118QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.8
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.8' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.8
+  - name: S2iThothUbi8Py36V0119QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.9
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.9' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.9
+  - name: S2iThothUbi8Py36V0143QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.3' has a size of 307.12MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.3
+  - name: S2iThothUbi8Py36V0160QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.16.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.16.0' has a size of 308.00MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.16.0
+  - name: S2iThothUbi8Py36V070QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.7.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.7.0' has a size of 267.25MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.7.0
+  - name: S2iThothUbi8Py36V050QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.5.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.5.0' has a size of 267.18MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.5.0
+  - name: S2iThothUbi8Py36V0140QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0' has a size of 324.25MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0
+  - name: S2iThothUbi8Py36V080QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.8.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.8.0' has a size of 267.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.8.0
+  - name: S2iThothUbi8Py36V0190QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.19.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.19.0' has a size of 483.06MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.19.0
+  - name: S2iThothUbi8Py36V0251QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.25.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.25.1' has a size of 309.03MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.25.1
+  - name: S2iThothUbi8Py36V0311QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.31.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.31.1' has a size of 343.11MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.31.1
+  - name: S2iThothUbi8Py36V0211QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.21.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.21.1' has a size of 315.16MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.21.1
+  - name: S2iThothUbi8Py36V0124QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.4' has a size of 276.43MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.4
+  - name: S2iThothUbi8Py36V01115QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.15
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.15' has a size of 272.52MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.15
+  - name: S2iThothUbi8Py36V0201QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.20.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.20.1' has a size of 485.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.20.1
+  - name: S2iThothUbi8Py36V0241QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.1' has a size of 311.75MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.1
+  - name: S2iThothUbi8Py36V0220QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.22.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.22.0' has a size of 315.45MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.22.0
+  - name: S2iThothUbi8Py36V010QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.1.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.1.0' has a size of 262.26MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.1.0
+  - name: S2iThothUbi8Py36V0161QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.16.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.16.1' has a size of 308.00MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.16.1
+  - name: S2iThothUbi8Py36V0123QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.3' has a size of 276.41MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.3
+  - name: S2iThothUbi8Py36V0116QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.6' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.6
+  - name: S2iThothUbi8Py36V0122QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.2' has a size of 276.41MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.2
+  - name: S2iThothUbi8Py36V020QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.2.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.2.0' has a size of 262.76MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.2.0
+  - name: S2iThothUbi8Py36V030QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.3.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.3.0' has a size of 262.76MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.3.0
+  - name: S2iThothUbi8Py36V0170QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.17.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.17.0' has a size of 309.70MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.17.0
+  - name: S2iThothUbi8Py36V0151QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.1' has a size of 308.04MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.1
+  - name: S2iThothUbi8Py36V0231QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.1' has a size of 329.32MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.1
+  - name: S2iThothUbi8Py36V01110QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.10
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.10' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.10
+  - name: S2iThothUbi8Py36V0120QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.0' has a size of 276.40MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.0
+  - name: S2iThothUbi8Py36V0270QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.27.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.27.0' has a size of 364.71MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.27.0
+  - name: S2iThothUbi8Py36V0115QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.5
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.5' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.5
+  - name: S2iThothUbi8Py36V0110QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.0' has a size of 257.19MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.0
+  - name: S2iThothUbi8Py36V0142QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.2' has a size of 317.95MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.2
+  - name: S2iThothUbi8Py36V0250QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.25.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.25.0' has a size of 309.03MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.25.0
+  - name: S2iThothUbi8Py36V01114QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.14
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.14' has a size of 272.47MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.14
+  - name: S2iThothUbi8Py36V01113QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.13
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.13' has a size of 272.48MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.13
+  - name: S2iThothUbi8Py36V0131QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.13.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.13.1' has a size of 276.13MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.13.1
+  - name: S2iThothUbi8Py36V0180QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.18.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.18.0' has a size of 308.84MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.18.0
+  - name: S2iThothUbi8Py36V0320QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.0' has a size of 360.38MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.0
+  - name: S2iThothUbi8Py36V0141QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.1' has a size of 317.94MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.1
+  - name: S2iThothUbi8Py36V0212QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.21.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.21.2' has a size of 315.45MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.21.2
+  - name: S2iThothUbi8Py36V060QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.6.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.6.0' has a size of 267.18MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.6.0
+  - name: S2iThothUbi8Py36V040QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.4.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.4.0' has a size of 267.14MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.4.0
+  - name: S2iThothUbi8Py36V0260QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.26.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.26.0' has a size of 309.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.26.0
+  - name: S2iThothUbi8Py36V0310QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.31.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.31.0' has a size of 343.11MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.31.0
+  - name: S2iThothUbi8Py36V090QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.9.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.9.0' has a size of 257.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.9.0
+  - name: S2iThothUbi8Py36V0126QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.6' has a size of 276.13MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.6
+  - name: S2iThothUbi8Py36V0323QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.3' has a size of 399.79MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.32.3
+  - name: S2iThothUbi8Py36V0114QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.4
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.4' has a size of 271.52MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.4
+  - name: S2iThothUbi8Py36V01111QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.11
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.11' has a size of 272.48MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.11
+  - name: S2iThothUbi8Py36V0130QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.13.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.13.0' has a size of 276.13MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.13.0
+  - name: S2iThothUbi8Py36V0121QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.1' has a size of 276.41MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.1
+  - name: S2iThothUbi8Py36V0200QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.20.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.20.0' has a size of 485.17MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.20.0
+  - name: S2iThothUbi8Py36V0112QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.2' has a size of 271.71MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.2
+  - name: S2iThothUbi8Py36V0230QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.0' has a size of 329.31MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.23.0
+  - name: S2iThothUbi8Py36V0242QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.2' has a size of 329.94MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.24.2
+  - name: S2iThothUbi8Py36V001QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.0.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.0.1' has a size of 262.26MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.0.1
+  - name: S2iThothUbi8Py36V0113QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.3' has a size of 271.38MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.11.3
+  - name: S2iThothUbi8Py36V0150QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0' has a size of 307.99MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0

--- a/prescriptions/_containers/s2i_thoth_ubi8_py38/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_ubi8_py38/quay_image_size.yaml
@@ -1,0 +1,470 @@
+units:
+  boots:
+  - name: S2iThothUbi8Py38V0151QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.15.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.15.1' has a size of 321.11MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.15.1
+  - name: S2iThothUbi8Py38V0180QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.18.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.18.0' has a size of 321.92MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.18.0
+  - name: S2iThothUbi8Py38V0290QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.29.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.29.0' has a size of 348.77MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.29.0
+  - name: S2iThothUbi8Py38V0322QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.2' has a size of 412.73MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.2
+  - name: S2iThothUbi8Py38V0131QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.13.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.13.1' has a size of 287.02MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.13.1
+  - name: S2iThothUbi8Py38V0251QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.25.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.25.1' has a size of 321.34MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.25.1
+  - name: S2iThothUbi8Py38V0142QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.2' has a size of 331.04MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.2
+  - name: S2iThothUbi8Py38V0320QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0' has a size of 373.48MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.0
+  - name: S2iThothUbi8Py38V0140QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.0' has a size of 337.37MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.0
+  - name: S2iThothUbi8Py38V0212QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.21.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.21.2' has a size of 327.00MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.21.2
+  - name: S2iThothUbi8Py38V0311QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.31.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.31.1' has a size of 376.37MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.31.1
+  - name: S2iThothUbi8Py38V0160QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.16.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.16.0' has a size of 321.11MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.16.0
+  - name: S2iThothUbi8Py38V0220QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.22.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.22.0' has a size of 327.00MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.22.0
+  - name: S2iThothUbi8Py38V0232QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.2' has a size of 341.89MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.2
+  - name: S2iThothUbi8Py38V0241QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.1' has a size of 324.29MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.1
+  - name: S2iThothUbi8Py38V0280QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.28.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.28.0' has a size of 348.77MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.28.0
+  - name: S2iThothUbi8Py38V0200QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.0' has a size of 514.24MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.0
+  - name: S2iThothUbi8Py38V0161QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.16.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.16.1' has a size of 321.11MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.16.1
+  - name: S2iThothUbi8Py38V0270QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.27.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.27.0' has a size of 377.26MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.27.0
+  - name: S2iThothUbi8Py38V0126QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.12.6
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.12.6' has a size of 287.01MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.12.6
+  - name: S2iThothUbi8Py38V0240QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.0' has a size of 341.86MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.0
+  - name: S2iThothUbi8Py38V0170QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.17.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.17.0' has a size of 322.81MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.17.0
+  - name: S2iThothUbi8Py38V0250QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.25.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.25.0' has a size of 321.34MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.25.0
+  - name: S2iThothUbi8Py38V0231QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.1' has a size of 341.88MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.1
+  - name: S2iThothUbi8Py38V0260QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.26.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.26.0' has a size of 321.49MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.26.0
+  - name: S2iThothUbi8Py38V0141QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.1' has a size of 331.02MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.1
+  - name: S2iThothUbi8Py38V0150QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.15.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.15.0' has a size of 321.09MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.15.0
+  - name: S2iThothUbi8Py38V0190QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.19.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.19.0' has a size of 512.15MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.19.0
+  - name: S2iThothUbi8Py38V0310QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.31.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.31.0' has a size of 376.37MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.31.0
+  - name: S2iThothUbi8Py38V0143QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.3' has a size of 320.26MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.14.3
+  - name: S2iThothUbi8Py38V0323QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.3' has a size of 412.73MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.32.3
+  - name: S2iThothUbi8Py38V0242QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.2' has a size of 342.43MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.24.2
+  - name: S2iThothUbi8Py38V0230QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.0' has a size of 341.88MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.23.0
+  - name: S2iThothUbi8Py38V0211QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.21.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.21.1' has a size of 326.74MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.21.1
+  - name: S2iThothUbi8Py38V0201QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1' has a size of 514.24MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1
+  - name: S2iThothUbi8Py38V0130QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.13.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.13.0' has a size of 287.02MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.13.0

--- a/prescriptions/_containers/s2i_thoth_ubi8_py39/quay_image_size.yaml
+++ b/prescriptions/_containers/s2i_thoth_ubi8_py39/quay_image_size.yaml
@@ -1,0 +1,80 @@
+units:
+  boots:
+  - name: S2iThothUbi8Py39V0322QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.2
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.2' has a size of 413.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.2
+  - name: S2iThothUbi8Py39V0300DevQuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.30.0-dev
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.30.0-dev' has a size of 313.04MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.30.0-dev
+  - name: S2iThothUbi8Py39V0310QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.31.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.31.0' has a size of 369.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.31.0
+  - name: S2iThothUbi8Py39V0320QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.0
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.0' has a size of 374.79MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.0
+  - name: S2iThothUbi8Py39V0323QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.3
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.3' has a size of 413.76MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.32.3
+  - name: S2iThothUbi8Py39V0311QuayImageSizeBoot
+    type: boot
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        base_images:
+        - quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.31.1
+    run:
+      stack_info:
+      - type: INFO
+        message: >-
+          Container image 'quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.31.1' has a size of 369.90MiB
+        link: https://quay.io/thoth-station/s2i-thoth-ubi8-py39:v0.31.1


### PR DESCRIPTION
## Related issues or additional information of the supplied change

Related: https://github.com/thoth-station/prescriptions-refresh-job

## Description

Show container image size if users use Thoth based container images.
