### PR TITLE
Provide prescriptions that select indexes based on labeled requests

### DIFF
--- a/prescriptions/_indexes/pypi.yaml
+++ b/prescriptions/_indexes/pypi.yaml
@@ -1,0 +1,29 @@
+units:
+  sieves:
+  - name: PyPIIndexSieve
+    type: sieve
+    should_include:
+      labels:
+        index: pypi
+    match:
+      package_version:
+        index_url:
+          not: https://pypi.org/simple
+    run:
+      stack_info:
+      - type: INFO
+        message: Using PyPI as a source of Python packages
+        link: https://pypi.org/simple
+  - name: NoPyPIIndexSieve
+    type: sieve
+    should_include:
+      labels:
+        index: no-pypi
+    match:
+      package_version:
+        index_url: https://pypi.org/simple
+    run:
+      stack_info:
+      - type: INFO
+        message: Ignoring packages provided by PyPI
+        link: https://pypi.org/simple

--- a/prescriptions/_indexes/pytorch_cpu.yaml
+++ b/prescriptions/_indexes/pytorch_cpu.yaml
@@ -1,0 +1,29 @@
+units:
+  sieves:
+  - name: PyTorchCPUIndexSieve
+    type: sieve
+    should_include:
+      labels:
+        index: pytorch-cpu
+    match:
+      package_version:
+        index_url:
+          not: https://download.pytorch.org/whl/cpu
+    run:
+      stack_info:
+      - type: INFO
+        message: Using PyTorch CPU index as a source of Python packages
+        link: https://download.pytorch.org/whl/cpu
+  - name: NoPyTorchCPUIndexSieve
+    type: sieve
+    should_include:
+      labels:
+        index: no-pytorch-cpu
+    match:
+      package_version:
+        index_url: https://download.pytorch.org/whl/cpu
+    run:
+      stack_info:
+      - type: INFO
+        message: Ignoring packages provided by PyTorch CPU index
+        link: https://download.pytorch.org/whl/cpu

--- a/prescriptions/_indexes/pytorch_cu111.yaml
+++ b/prescriptions/_indexes/pytorch_cu111.yaml
@@ -1,0 +1,29 @@
+units:
+  sieves:
+  - name: PyTorchCU111IndexSieve
+    type: sieve
+    should_include:
+      labels:
+        index: pytorch-cu111
+    match:
+      package_version:
+        index_url:
+          not: https://download.pytorch.org/whl/cu111
+    run:
+      stack_info:
+      - type: INFO
+        message: Using PyTorch CUDA 11.1 index as a source of Python packages
+        link: https://download.pytorch.org/whl/cu111
+  - name: NoPyTorchCU111IndexSieve
+    type: sieve
+    should_include:
+      labels:
+        index: no-pytorch-cu111
+    match:
+      package_version:
+        index_url: https://download.pytorch.org/whl/cu111
+    run:
+      stack_info:
+      - type: INFO
+        message: Ignoring packages provided by PyTorch CUDA 11.1 index
+        link: https://download.pytorch.org/whl/cu111


### PR DESCRIPTION
## Description

With these prescriptions, people can select which index should be used or should not be used based on the labels they provide to the resolver.
