### PR TITLE
Avoid clashing label keys when selecting indexes

### DIFF
--- a/prescriptions/_indexes/pypi.yaml
+++ b/prescriptions/_indexes/pypi.yaml
@@ -4,7 +4,7 @@ units:
     type: sieve
     should_include:
       labels:
-        index: pypi
+        pypi-index: solely
     match:
       package_version:
         index_url:
@@ -18,7 +18,7 @@ units:
     type: sieve
     should_include:
       labels:
-        index: no-pypi
+        pypi-index: off
     match:
       package_version:
         index_url: https://pypi.org/simple

--- a/prescriptions/_indexes/pytorch_cpu.yaml
+++ b/prescriptions/_indexes/pytorch_cpu.yaml
@@ -4,7 +4,7 @@ units:
     type: sieve
     should_include:
       labels:
-        index: pytorch-cpu
+        pytorch-cpu-index: solely
     match:
       package_version:
         index_url:
@@ -18,7 +18,7 @@ units:
     type: sieve
     should_include:
       labels:
-        index: no-pytorch-cpu
+        pytorch-cpu-index: off
     match:
       package_version:
         index_url: https://download.pytorch.org/whl/cpu

--- a/prescriptions/_indexes/pytorch_cu111.yaml
+++ b/prescriptions/_indexes/pytorch_cu111.yaml
@@ -4,7 +4,7 @@ units:
     type: sieve
     should_include:
       labels:
-        index: pytorch-cu111
+        pytorch-cu111-index: solely
     match:
       package_version:
         index_url:
@@ -18,7 +18,7 @@ units:
     type: sieve
     should_include:
       labels:
-        index: no-pytorch-cu111
+        pytorch-cu111-index: off
     match:
       package_version:
         index_url: https://download.pytorch.org/whl/cu111


### PR DESCRIPTION
## Description

Adjust labels to filter indexes. Previously, it was not possible to use configurations like:

```
thamos advise --labels "index=no-pypi,index=no-pytorch-cu111"
```

as each label key is unique. Rather, use the proposed configuration to have the ability to select index filtering:

```
thamos advise --labels "pypi-index=off,pytorch-cu111-index=off"
```