### PR TITLE
Cannot install connexion when using markupsafe>=2.1.0

### DIFF
--- a/prescriptions/co_/connexion/markupsafe_210.yaml
+++ b/prescriptions/co_/connexion/markupsafe_210.yaml
@@ -7,14 +7,13 @@ units:
     match:
     - group:
       - package_version:
-        name: connexion
-        index_url: https://pypi.org/simple
+          name: connexion
+          index_url: https://pypi.org/simple
       - package_version:
-        name: markupsafe
-        version: ">=2.1.0"
-        index_url: https://pypi.org/simple
+          name: markupsafe
+          version: ">=2.1.0"
+          index_url: https://pypi.org/simple
     run:
-      multi_package_resolution: true
       stack_info:
       - &stack_info
         type: WARNING
@@ -36,7 +35,6 @@ units:
     match:
       package_version:
         name: connexion
-        version: "*"
         index_url: https://pypi.org/simple
     run:
       stack_info:

--- a/prescriptions/co_/connexion/markupsafe_210.yaml
+++ b/prescriptions/co_/connexion/markupsafe_210.yaml
@@ -1,18 +1,18 @@
 units:
   steps:
   - name: ConnexionMarkupsafe210Step
-    type: step
+    type: step.Group
     should_include:
       adviser_pipeline: true
     match:
-      package_version:
+    - group:
+      - package_version:
         name: connexion
-        version: "*"
         index_url: https://pypi.org/simple
-      state:
-        resolved_dependencies:
-        - name: markupsafe
-          version: ">=2.1.0"
+      - package_version:
+        name: markupsafe
+        version: ">=2.1.0"
+        index_url: https://pypi.org/simple
     run:
       multi_package_resolution: true
       stack_info:

--- a/prescriptions/co_/connexion/markupsafe_210.yaml
+++ b/prescriptions/co_/connexion/markupsafe_210.yaml
@@ -1,0 +1,43 @@
+units:
+  steps:
+  - name: ConnexionMarkupsafe210Step
+    type: step
+    should_include:
+      adviser_pipeline: true
+    match:
+      package_version:
+        name: connexion
+        version: "*"
+        index_url: https://pypi.org/simple
+      state:
+        resolved_dependencies:
+        - name: markupsafe
+          version: ">=2.1.0"
+    run:
+      multi_package_resolution: true
+      stack_info:
+      - &stack_info
+        type: WARNING
+        message: Cannot install connexion when using markupsafe>=2.1.0
+        link: https://github.com/thoth-station/user-api/pull/1681
+      not_acceptable: Cannot install connexion when using markupsafe>=2.1.0
+  sieves:
+  - name: ConnexionMarkupsafe210Sieve
+    type: sieve
+    should_include:
+      adviser_pipeline: true
+      runtime_environments:
+        # Filter connexion if Python container images are
+        # shipped with the specified markupsafe.
+        python_packages:
+        - name: markupsafe
+          version: ">=2.1.0"
+          location: ^/opt/app-root/.*
+    match:
+      package_version:
+        name: connexion
+        version: "*"
+        index_url: https://pypi.org/simple
+    run:
+      stack_info:
+      - <<: *stack_info


### PR DESCRIPTION
## Related issues or additional information of the supplied change

Related to https://github.com/thoth-station/user-api/pull/1681#issuecomment-1049085925

## Description

Prescription for installing `markupsafe <2.1.0` with `connexion` 
