### PR TITLE
Replace `connexion` with `jinja2` in `markupsafe` prescription

### DIFF
--- a/prescriptions/ma_/markupsafe/jinja23_markupsafe210.yaml
+++ b/prescriptions/ma_/markupsafe/jinja23_markupsafe210.yaml
@@ -1,13 +1,14 @@
 units:
   steps:
-  - name: ConnexionMarkupsafe210Step
+  - name: Jinja23Markupsafe210Step
     type: step.Group
     should_include:
       adviser_pipeline: true
     match:
     - group:
       - package_version:
-          name: connexion
+          name: jinja2
+          version: <3.0.0
           index_url: https://pypi.org/simple
       - package_version:
           name: markupsafe
@@ -17,16 +18,16 @@ units:
       stack_info:
       - &stack_info
         type: WARNING
-        message: Cannot install connexion when using markupsafe>=2.1.0
-        link: https://github.com/thoth-station/user-api/pull/1681
-      not_acceptable: Cannot install connexion when using markupsafe>=2.1.0
+        message: Cannot install jinja2<3.0.0 when using markupsafe>=2.1.0
+        link: https://github.com/pallets/markupsafe/blob/main/CHANGES.rst#version-210
+      not_acceptable: Cannot install jinja2<3.0.0 when using markupsafe>=2.1.0
   sieves:
-  - name: ConnexionMarkupsafe210Sieve
+  - name: Jinja23Markupsafe210Sieve
     type: sieve
     should_include:
       adviser_pipeline: true
       runtime_environments:
-        # Filter connexion if Python container images are
+        # Filter jinja2 if Python container images are
         # shipped with the specified markupsafe.
         python_packages:
         - name: markupsafe
@@ -34,7 +35,8 @@ units:
           location: ^/opt/app-root/.*
     match:
       package_version:
-        name: connexion
+        name: jinja2
+        version: <3.0.0
         index_url: https://pypi.org/simple
     run:
       stack_info:


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- No

## This Pull Request implements
Replace `connexion` by `jinja2` in `markupsafe` prescription.

cc @harshad16 @fridex 
