### PR TITLE
Cannot install jinja2 >=2.0,<=2.6 with setuptools >46,==3.0,==3.0.1,==3.0.2

### DIFF
--- a/prescriptions/ji_/jinja2/setuptools46.yaml
+++ b/prescriptions/ji_/jinja2/setuptools46.yaml
@@ -1,0 +1,23 @@
+units:
+  steps:
+  - name: Setuptools46xJinja2Step
+    type: step.Group
+    should_include:
+      adviser_pipeline: true
+    match:
+    - group:
+      - package_version:
+          name: setuptools
+          version: ">46,==3.0,==3.0.1,==3.0.2"
+          index_url: https://pypi.org/simple
+      - package_version:
+          name: jinja2
+          version: ">=2.0,<=2.6"
+          index_url: https://pypi.org/simple
+    run:
+      stack_info:
+      - &stack_info
+        type: WARNING
+        message: Cannot install jinja2>=2.0,<=2.6 with setuptools>46,==3.0,==3.0.1,==3.0.2
+        link: https://github.com/pypa/setuptools/issues/2017
+      not_acceptable: Cannot install jinja2>=2.0,<=2.6 with setuptools>46,==3.0,==3.0.1,==3.0.2

--- a/prescriptions/ji_/jinja2/setuptools46.yaml
+++ b/prescriptions/ji_/jinja2/setuptools46.yaml
@@ -16,8 +16,7 @@ units:
           index_url: https://pypi.org/simple
     run:
       stack_info:
-      - &stack_info
-        type: WARNING
+      - type: WARNING
         message: Cannot install jinja2>=2.0,<=2.6 with setuptools>46,==3.0,==3.0.1,==3.0.2
         link: https://github.com/pypa/setuptools/issues/2017
       not_acceptable: Cannot install jinja2>=2.0,<=2.6 with setuptools>46,==3.0,==3.0.1,==3.0.2


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/pypa/setuptools/issues/2017

## This introduces a breaking change

- No

## This should yield a new module release

- No
