### PR TITLE
Add prescription for CVE-2022-30877 on keep

### DIFF
--- a/prescriptions/ke_/keep/cve_2022_30877.yaml
+++ b/prescriptions/ke_/keep/cve_2022_30877.yaml
@@ -1,0 +1,19 @@
+units:
+  sieves:
+  - name: Keep12CVESieve
+    type: sieve
+    should_include:
+      adviser_pipeline: true
+    match:
+    - package_version:
+        name: keep
+        version: ==1.2
+        index_url: https://pypi.org/simple
+    run:
+      log:
+        type: WARNING
+        message: Removing version 1.2 of the 'keep' package as it contains a code-execution backdoor (CVE-2022-30877)
+      stack_info:
+      - type: WARNING
+        message: Removing version 1.2 of the 'keep' package as it contains a code-execution backdoor (CVE-2022-30877)
+        link: cve


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #25117

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No (we do not have that package in the database for now)

## This Pull Request implements

Remove version 1.2 of the `keep` package as distributed on PyPI.

## Description

<!--- Describe your changes in detail -->

See https://nvd.nist.gov/vuln/detail/CVE-2022-30877 for more details on the vulnerability (although the current description of the CVE is misleading: version 1.2 is the one affected)