### PR TITLE
Revert "Run pre-commit only on modified files from PR"

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -10,8 +10,7 @@ presubmits:
       command:
       - pre-commit
       - run
-      - --from-ref origin/HEAD
-      - --to-ref HEAD
+      - --all-files
       resources:
         requests:
           memory: 1Gi


### PR DESCRIPTION
Reverts thoth-station/prescriptions#27401

as it results in an error:
```
usage: pre-commit [-h] [-V]
                  {autoupdate,clean,hook-impl,gc,init-templatedir,install,install-hooks,migrate-config,run,sample-config,try-repo,uninstall,help}
                  ...
pre-commit: error: unrecognized arguments: --to-ref HEAD
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2022-08-20T19:38:39Z"}
```