### PR TITLE
Run pre-commit only on the files modified by the PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 ---
 repos:
 - repo: https://github.com/Lucas-C/pre-commit-hooks
-  rev: v1.1.13
+  rev: v1.3.1
   hooks:
   - id: remove-tabs
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
 
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.26.3
+  rev: v1.28.0
   hooks:
   - id: yamllint
     args: [-c=.yamllint]

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,11 +6,14 @@ presubmits:
   context: aicoe-ci/prow/pre-commit
   spec:
     containers:
-    - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.9
+    - image: quay.io/thoth-station/thoth-precommit-py38:v0.15.0
       command:
       - pre-commit
       - run
-      - --all-files
+      - --from-ref
+      - HEAD@{1}
+      - --to-ref
+      - HEAD
       resources:
         requests:
           memory: 1Gi


### PR DESCRIPTION
## Related Issues and Dependencies

This is a redux of #27401

It should help with https://github.com/thoth-station/prescriptions-refresh-job/issues/52

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

## This Pull Request implements

Modify the pre-commit configuration so that it runs only on the changed files.

Doc on this: https://pre-commit.com/#usage-in-continuous-integration

## Description

<!--- Describe your changes in detail -->

The previous attempt in #27401 had e.g. `"--to-ref HEAD"` as a single argument (instead of 2), which caused an error, leading to it being reverted in https://github.com/thoth-station/prescriptions/pull/27402.

Also taking the opportunity to update the pre-commit image version
