### PR TITLE
Document information source for prescriptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,16 +47,16 @@ Data sources used for automatically generated prescriptions
 ===========================================================
 
 Currently implemented `handlers
-<https://github.com/thoth-station/prescriptions-refresh-job/tree/master/thoth/prescriptions_refresh/handlers>`__
+<https://github.com/thoth-station/prescriptions-refresh-job/tree/master/thoth/prescriptions_refresh/handlers>`_
 in Thoth's weekly cronjob allow to auto-generate prescriptions for the given data:
 
 - CVE present in a package, from the `PyPA advisory-database
-<https://github.com/pypa/advisory-database>`__
+<https://github.com/pypa/advisory-database>`_
 - Project maintenance and development practices as evaluated by the `OSSF Security Scorecards
-<https://github.com/ossf/scorecard>___
+<https://github.com/ossf/scorecard>`_
 - Information on package maintainance obtained via the GitHub API: if the given project is marked as archived, is forked from another project, hosts release notes, its number of maintainers, stars, contributors.
 - The package size, number of downloads, maintainers and last release date from `PyPI
-<https://pypi.org/>`___.
+<https://pypi.org/>`_.
 
 Release Details
 ==============================

--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,7 @@ in Thoth's weekly cronjob allow to auto-generate prescriptions for the given dat
 - CVE present in a package, from the `PyPA advisory-database <https://github.com/pypa/advisory-database>`_
 - Project maintenance and development practices as evaluated by the `OSSF Security Scorecards <https://github.com/ossf/scorecard>`_
 - Information on package maintainance obtained via the GitHub API: if the given project is marked as archived, is forked from another project, hosts release notes, its number of maintainers, stars, contributors.
-- The package size, number of downloads, maintainers and last release date from `PyPI
-<https://pypi.org/>`_.
+- The package size, number of downloads, maintainers and last release date from `PyPI <https://pypi.org/>`_.
 
 Release Details
 ==============================

--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,8 @@ Currently implemented `handlers
 <https://github.com/thoth-station/prescriptions-refresh-job/tree/master/thoth/prescriptions_refresh/handlers>`_
 in Thoth's weekly cronjob allow to auto-generate prescriptions for the given data:
 
-- CVE present in a package, from the `PyPA advisory-database
-<https://github.com/pypa/advisory-database>`_
-- Project maintenance and development practices as evaluated by the `OSSF Security Scorecards
-<https://github.com/ossf/scorecard>`_
+- CVE present in a package, from the `PyPA advisory-database <https://github.com/pypa/advisory-database>`_
+- Project maintenance and development practices as evaluated by the `OSSF Security Scorecards <https://github.com/ossf/scorecard>`_
 - Information on package maintainance obtained via the GitHub API: if the given project is marked as archived, is forked from another project, hosts release notes, its number of maintainers, stars, contributors.
 - The package size, number of downloads, maintainers and last release date from `PyPI
 <https://pypi.org/>`_.

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,21 @@ Need help with a prescription?
 If you spotted an issue in Python dependencies or Python ecosystem, just let us
 know by openning an issue and we will help you with writing a prescription.
 
+Data sources used for automatically generated prescriptions
+===========================================================
+
+Currently implemented `handlers
+<https://github.com/thoth-station/prescriptions-refresh-job/tree/master/thoth/prescriptions_refresh/handlers>`__
+in Thoth's weekly cronjob allow to auto-generate prescriptions for the given data:
+
+- CVE present in a package, from the `PyPA advisory-database
+<https://github.com/pypa/advisory-database>`__
+- Project maintenance and development practices as evaluated by the `OSSF Security Scorecards
+<https://github.com/ossf/scorecard>___
+- Information on package maintainance obtained via the GitHub API: if the given project is marked as archived, is forked from another project, hosts release notes, its number of maintainers, stars, contributors.
+- The package size, number of downloads, maintainers and last release date from `PyPI
+<https://pypi.org/>`___.
+
 Release Details
 ==============================
 


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #33389 

## This introduces a breaking change

- No 

## This should yield a new module release

- No

## This Pull Request implements

Document sources used to compute automatically generated prescriptions.
