### PR TITLE
validate prescriptions with pre-commit hook using adviser

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,10 @@ repos:
   hooks:
   - id: yamllint
     args: [-c=.yamllint]
+
+- repo: https://github.com/thoth-station/adviser.git
+  rev: 0669b0ea595e9eb59998efb11a236d3039dacdf8
+  hooks:
+  - id: validate-prescriptions
+    files: prescriptions/
+    exclude: prescriptions/_prescription_metadata.yaml


### PR DESCRIPTION
## Related Issues and Dependencies
fix #8
thoth-station/adviser#2402
## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

## This Pull Request implements

Add a pre-commit hooks to validate prescriptions.
In conjonction with --from-ref / --to-ref, this should only validates files touched in a PR

This on my fork of thoth-station/adviser because it needs thoth-station/adviser#2411 and thoth-station#2408 to be merged first.


By the way, we really need operate-first/apps#2462 on this repo. It would allow us to implement pre-commit hook caching instead of installing every single time, which would save a lot of prow-time. (well, once it comes back up...)

/hold
